### PR TITLE
feat(exercises): Add user's exercises view with play and delete

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -55,9 +55,9 @@ def start_application():
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    static_files_path = "users_videos"
+    static_files_path = "/videos"
     os.makedirs(static_files_path, exist_ok=True)
-    app.mount("/users_videos", StaticFiles(directory=static_files_path), name="videos")
+    app.mount("/videos", StaticFiles(directory=static_files_path), name="videos")
     create_table()
     return app
 

--- a/backend/routers/exercise_routers.py
+++ b/backend/routers/exercise_routers.py
@@ -63,10 +63,7 @@ async def delete_last_exercise(db: Session = Depends(get_db)):
 async def get_my_exercises(
     db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
-    """
-    Zwraca listę wszystkich ćwiczeń (wraz z wideo i partią ciała)
-    utworzonych przez aktualnie zalogowanego użytkownika.
-    """
+  
     exercises = (
         db.query(Exercise)
         .filter(Exercise.user_id == current_user.id)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       dockerfile: dockerfile
     volumes:
       - ./backend:/code
+      - ./users_videos:/videos
     ports:
       - "8080:80"
     depends_on:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "autoprefixer": "^10.4.21",
         "axios": "^1.9.0",
+        "lucide-react": "^0.534.0",
         "postcss": "^8.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3009,6 +3010,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.534.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.534.0.tgz",
+      "integrity": "sha512-4Bz7rujQ/mXHqCwjx09ih/Q9SCizz9CjBV5repw9YSHZZZaop9/Oj0RgCDt6WdEaeAPfbcZ8l2b4jzApStqgNw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.21",
     "axios": "^1.9.0",
+    "lucide-react": "^0.534.0",
     "postcss": "^8.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import StartPage from "./pages/StarPage"
 import Dashboard from "./pages/Dashboard";
 import { ProtectedRoute } from "./components/ProtectRoute";
 import AddExercise from "./pages/AddExercise";
+import MyExercisesPage from "./pages/MyExercisesPage";
 function App() {
   return (
     <Router>
@@ -18,6 +19,8 @@ function App() {
         <Route path="/TrainerDashboard" element={<TrainerDashboard />} />
         <Route path="/dashboard"element={<ProtectedRoute><Dashboard /></ProtectedRoute>}/>
         <Route path="/addExercise"element={<ProtectedRoute><AddExercise/></ProtectedRoute>}/>
+        <Route path="/my-exercises"element={<ProtectedRoute><MyExercisesPage/></ProtectedRoute>}/>
+
       </Routes>
     </Router>
   );

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { logout as apiLogout } from "../api/auth";
-import { useAuth } from "../context/AuthContext"; // <- import kontekstu
+import { useAuth } from "../context/AuthContext"; 
 
 interface ButtonProps {
   children: React.ReactNode;
@@ -30,7 +30,6 @@ export const PrimaryButton: React.FC<ButtonProps> = ({ children, onClick, type =
   </button>
 );
 
-// Przyciski dodatkowe (np. szary, czerwony)
 export const SecondaryButton: React.FC<ButtonProps> = ({ children, onClick, type = "button" }) => (
   <button
     onClick={onClick}
@@ -57,7 +56,7 @@ export const ConstSizeButton: React.FC<ButtonProps> = ({ children, onClick, type
     onClick={onClick}
     type={type}
     className="bg-blue-500 text-white p-2 rounded-lg hover:bg-blue-600 transition mb-4"
-    style={{ width: "150px", height: "50px", marginRight: "15px" }} // Ustalona szerokość i wysokość
+    style={{ width: "150px", height: "50px", marginRight: "15px" }} 
   >
     {children}
   </button>
@@ -75,17 +74,17 @@ export const SmallButton: React.FC<ButtonProps> = ({ children, onClick, type = "
 
 export const LogoutButton: React.FC<ButtonProps> = ({ children, type = "button" }) => {
   const navigate = useNavigate();
-  const { logout, token } = useAuth(); // <- pobieramy logout z kontekstu
+  const { logout, token } = useAuth(); 
 
   const handleLogout = async () => {
     if (!token) return;
 
     try {
-      await apiLogout(token); // <- wysyłamy token
+      await apiLogout(token);
     } catch (error) {
       console.error("Logout failed:", error);
     } finally {
-      logout(); // <- czyści stan kontekstu
+      logout(); 
       navigate("/login");
     }
   };

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -7,7 +7,7 @@ interface InputProps {
     type?: string;
     value: string;
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
-    error?: string;  // Dodajemy właściwość błędu
+    error?: string;
 }
   
 const Input: React.FC<InputProps> = ({

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -76,10 +76,12 @@ export const TrainerSidebar: React.FC<SidebarProps> = ({ username, email, profil
 
         <ConstSizeButton>Ustawienia Konta</ConstSizeButton>
         <Link to="/addExercise" className="w-full" style={{marginRight: "-40px"}}>
-        <ConstSizeButton >Dodaj ćwiczenie</ConstSizeButton>
+          <ConstSizeButton >Dodaj ćwiczenie</ConstSizeButton>
         </Link>
         <ConstSizeButton>Moi podopieczni</ConstSizeButton>
-        <ConstSizeButton>Moje ćwiczenia</ConstSizeButton>
+        <Link to="/my-exercises" className="w-full">
+          <ConstSizeButton>Moje ćwiczenia</ConstSizeButton>
+        </Link>
         <LogoutButton>Wyloguj</LogoutButton>
       </div>
     </aside>

--- a/frontend/src/pages/MyExercisesPage.tsx
+++ b/frontend/src/pages/MyExercisesPage.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import MainLayout from '../components/MainLayout';
+import { getMyExercises, deleteExercise, UserExercise } from '../services/api';
+import { Trash2, Video } from 'lucide-react'; 
+
+const VideoModal = ({ exercise, onClose }: { exercise: UserExercise; onClose: () => void }) => {
+    const videoUrl = `http://localhost:8080/videos/${exercise.videos[0]?.video_path}`;
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50" onClick={onClose}>
+          <div className="bg-gray-800 p-6 rounded-lg max-w-3xl w-full" onClick={(e) => e.stopPropagation()}>
+            <h2 className="text-2xl font-bold text-white mb-4">{exercise.exercise_name}</h2>
+            {exercise.videos.length > 0 ? (
+              <video src={videoUrl} controls autoPlay className="w-full rounded-md mb-4">
+                Twoja przeglądarka nie obsługuje tagu wideo.
+              </video>
+            ) : (
+              <p className="text-gray-400 mb-4">Brak wideo dla tego ćwiczenia.</p>
+            )}
+            <h3 className="text-lg font-semibold text-white">Opis:</h3>
+            <p className="text-gray-300 mt-2">{exercise.description || 'Brak opisu.'}</p>
+            <button onClick={onClose} className="mt-6 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">
+              Zamknij
+            </button>
+          </div>
+        </div>
+      );
+    };
+
+    const MyExercisesPage = () => {
+        const [exercises, setExercises] = useState<UserExercise[]>([]);
+        const [isLoading, setIsLoading] = useState(true);
+        const [error, setError] = useState<string | null>(null);
+        const [selectedExercise, setSelectedExercise] = useState<UserExercise | null>(null);
+      
+        useEffect(() => {
+          const fetchExercises = async () => {
+            try {
+              const data = await getMyExercises();
+              setExercises(data);
+            } catch (err: any) {
+              setError(err.message);
+            } finally {
+              setIsLoading(false);
+            }
+          };
+          fetchExercises();
+        }, []);
+      
+        const handleDelete = async (exerciseId: number) => {
+          if (window.confirm("Czy na pewno chcesz usunąć to ćwiczenie i wszystkie powiązane z nim wideo?")) {
+              try {
+                  await deleteExercise(exerciseId);
+                  setExercises(prev => prev.filter(ex => ex.id !== exerciseId));
+              } catch (err: any) {
+                  setError(err.message);
+              }
+          }
+        };
+      
+        const renderContent = () => {
+          if (isLoading) return <p className="text-white">Ładowanie Twoich ćwiczeń...</p>;
+          if (error) return <p className="text-red-500">Błąd: {error}</p>;
+          if (exercises.length === 0) return <p className="text-white">Nie dodałeś jeszcze żadnych ćwiczeń.</p>;
+      
+          return (
+            <div className="bg-gray-800 shadow-md rounded-lg p-4">
+              <ul className="divide-y divide-gray-700">
+                {exercises.map((exercise) => (
+                  <li key={exercise.id} className="py-4 flex items-center justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <p 
+                        className="text-sm font-medium text-indigo-400 truncate cursor-pointer hover:underline"
+                        onClick={() => setSelectedExercise(exercise)}
+                      >
+                        {exercise.exercise_name}
+                      </p>
+                      <p className="text-sm text-gray-400">{exercise.body_part_name}</p>
+                    </div>
+                    <div className="text-sm text-gray-500 hidden md:block">
+                      {exercise.videos.length > 0 ? new Date(exercise.videos[0].create_at).toLocaleDateString() : 'Brak wideo'}
+                    </div>
+                    <div className="text-sm text-gray-500 truncate hidden lg:block" title={exercise.videos[0]?.video_path}>
+                      {exercise.videos.length > 0 ? <Video className="inline-block" size={16}/> : 'Brak'}
+                    </div>
+                    <button onClick={() => handleDelete(exercise.id)} className="text-red-500 hover:text-red-400 flex-shrink-0">
+                      <Trash2 size={20} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        };
+      
+        return (
+          <MainLayout>
+            <h1 className="text-3xl font-bold mb-6 text-white">Moje Ćwiczenia</h1>
+            {renderContent()}
+            {selectedExercise && <VideoModal exercise={selectedExercise} onClose={() => setSelectedExercise(null)} />}
+          </MainLayout>
+        );
+      };
+      
+      export default MyExercisesPage;
+      


### PR DESCRIPTION
This commit introduces a new feature allowing trainers to manage their own exercises.

- Adds a new page at `/my-exercises` to display a list of all exercises created by the logged-in user.
- The list includes exercise name, body part, and video creation date.
- Implements a modal to play the associated video and view the exercise description upon clicking an exercise name.
- Adds a delete functionality with a confirmation prompt to remove the exercise and its associated video file and database entries.
- Includes new API service functions (`getMyExercises`, `deleteExercise`) to communicate with the backend.
