### PR TITLE
feat(api): Add endpoint to fetch exercises by body part

### DIFF
--- a/backend/schemas/exercise.py
+++ b/backend/schemas/exercise.py
@@ -30,3 +30,20 @@ class UserExerciseResponse(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class ExerciseTrainerResponse(BaseModel):
+    first_name: str
+    last_name: str
+
+    class Config:
+        orm_mode = True
+
+
+class ExerciseWithTrainerResponse(BaseModel):
+    id: int
+    exercise_name: str
+    user: ExerciseTrainerResponse  
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
Closes #2
## What was done?

- Added a new endpoint GET /exercise/by-body-part/{body_part_id}.
- The endpoint returns a list of exercises for the specified body part.
- Each returned exercise object now contains nested trainer data (first and last name) of the trainer who added it.
- Created new Pydantic schemas (ExerciseWithTrainerResponse, ExerciseTrainerResponse) for response validation.

## How to test?
The endpoint can be tested using Swagger UI documentation at /docs after running the application. You need to provide an ID of an existing body part.