### PR TITLE
Feat/03/frontend user select exercises

### DIFF
--- a/frontend/src/pages/FindExercisePage.tsx
+++ b/frontend/src/pages/FindExercisePage.tsx
@@ -1,10 +1,7 @@
-// src/pages/FindExercisePage.tsx
-
 import React, { useState, useEffect } from 'react';
 import MainLayout from '../components/MainLayout';
-import { getBodyParts } from '../services/api'; 
+import { getBodyParts, getExercisesByBodyPart, ExerciseWithTrainer } from '../services/api'; 
 
-// Definicja typu dla partii ciała
 interface BodyPart {
   id: number;
   body_part_name: string;
@@ -12,10 +9,11 @@ interface BodyPart {
 
 const FindExercisePage = () => {
   const [bodyParts, setBodyParts] = useState<BodyPart[]>([]);
+  const [selectedBodyPart, setSelectedBodyPart] = useState<BodyPart | null>(null);
+  const [exercises, setExercises] = useState<ExerciseWithTrainer[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Pobieranie listy partii ciała przy pierwszym załadowaniu strony
   useEffect(() => {
     const fetchInitialData = async () => {
       try {
@@ -30,38 +28,82 @@ const FindExercisePage = () => {
     fetchInitialData();
   }, []);
 
-  // Funkcja renderująca zawartość strony
-  const renderContent = () => {
-    if (isLoading) {
-      return <p className="text-white">Ładowanie partii ciała...</p>;
+  const handleSelectBodyPart = async (part: BodyPart) => {
+    setSelectedBodyPart(part);
+    setIsLoading(true);
+    setError(null);
+    try {
+      const exercisesData = await getExercisesByBodyPart(part.id);
+      setExercises(exercisesData);
+    } catch (err: any) {
+      setError(err.message);
+      setExercises([]);
+    } finally {
+      setIsLoading(false);
     }
-    if (error) {
-      return <p className="text-red-500">Błąd: {error}</p>;
-    }
-
-    // Widok wyboru partii ciała w formie siatki
-    return (
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {bodyParts.map((part) => (
-          <button
-            key={part.id}
-            // Na razie kliknięcie nic nie robi, dodamy to w następnym kroku
-            onClick={() => alert(`Wybrano: ${part.body_part_name}`)}
-            className="p-6 bg-gray-700 rounded-lg text-white font-semibold text-center hover:bg-indigo-600 transition-colors"
-          >
-            {part.body_part_name}
-          </button>
-        ))}
-      </div>
-    );
   };
 
+  const renderExercisesTable = () => (
+    <div>
+      <button 
+        onClick={() => setSelectedBodyPart(null)} 
+        className="mb-6 px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-500 transition-colors"
+      >
+        &larr; Wróć do wyboru partii
+      </button>
+      <h2 className="text-2xl font-semibold text-white mb-4">
+        Ćwiczenia dla: <span className="text-indigo-400">{selectedBodyPart?.body_part_name}</span>
+      </h2>
+      {isLoading ? (
+        <p className="text-white">Ładowanie ćwiczeń...</p>
+      ) : exercises.length > 0 ? (
+        <div className="overflow-x-auto bg-gray-800 rounded-lg">
+          <table className="min-w-full text-sm text-left text-gray-300">
+            <thead className="text-xs text-gray-400 uppercase bg-gray-700">
+              <tr>
+                <th scope="col" className="px-6 py-3">Nazwa ćwiczenia</th>
+                <th scope="col" className="px-6 py-3">Dodane przez</th>
+              </tr>
+            </thead>
+            <tbody>
+              {exercises.map(exercise => (
+                <tr key={exercise.id} className="border-b border-gray-700 hover:bg-gray-600">
+                  <td className="px-6 py-4 font-medium text-white">{exercise.exercise_name}</td>
+                  <td className="px-6 py-4">{`${exercise.user.first_name} ${exercise.user.last_name}`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-white">Brak dostępnych ćwiczeń dla tej partii ciała.</p>
+      )}
+    </div>
+  );
+
+  const renderBodyPartSelection = () => (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+       {bodyParts.map((part) => (
+         <button
+           key={part.id}
+           onClick={() => handleSelectBodyPart(part)}
+           className="p-6 bg-gray-700 rounded-lg text-white font-semibold text-center hover:bg-indigo-600 transition-colors"
+         >
+           {part.body_part_name}
+         </button>
+       ))}
+     </div>
+ );
   return (
     <MainLayout>
       <h1 className="text-3xl font-bold mb-6 text-white">Znajdź Ćwiczenie</h1>
-      {renderContent()}
+      {isLoading && !selectedBodyPart && <p className="text-white">Ładowanie partii ciała...</p>}
+      {error && <p className="text-red-500">Błąd: {error}</p>}
+      
+      {!isLoading && (selectedBodyPart ? renderExercisesTable() : renderBodyPartSelection())}
     </MainLayout>
   );
 };
 
 export default FindExercisePage;
+

--- a/frontend/src/services/api.tsx
+++ b/frontend/src/services/api.tsx
@@ -132,3 +132,28 @@ export const deleteExercise = async (exerciseId: number): Promise<void> => {
       throw new Error("Nie można usunąć ćwiczenia. Sprawdź połączenie.");
   }
 };
+
+
+interface ExerciseTrainer {
+  first_name: string;
+  last_name: string;
+}
+
+export interface ExerciseWithTrainer {
+  id: number;
+  exercise_name: string;
+  user: ExerciseTrainer; 
+}
+
+
+export const getExercisesByBodyPart = async (bodyPartId: number): Promise<ExerciseWithTrainer[]> => {
+  try {
+    const response = await apiClient.get<ExerciseWithTrainer[]>(`/exercise/by-body-part/${bodyPartId}`);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.detail || "Błąd podczas pobierania ćwiczeń");
+    }
+    throw new Error("Nie można pobrać ćwiczeń dla tej partii ciała.");
+  }
+};


### PR DESCRIPTION
closes #3
Depends on #25 

##  What was done?

- Extended the "Find Exercise" page to display a table with a list of exercises after clicking on a body part.
- The table contains columns "Exercise Name" and "Added by" (trainer's first and last name).
- Implemented logic for fetching data from the new API endpoint.
- Added a "Back" button that allows returning to the body part selection view.

## How to test?

1. Log in as a user.
2. Go to "Find Exercise".
3. Click on a body part that has some exercises.
4. Check if the table with exercise names and their authors displays correctly.
5. Check if the "Back" button works properly.

## Screenshot
<img width="1632" height="548" alt="image" src="https://github.com/user-attachments/assets/be69e323-9a2a-465c-a35c-050ef2caa75f" />
