### PR TITLE
feat(users): Implement profile picture upload

### DIFF
--- a/backend/auth/schemas.py
+++ b/backend/auth/schemas.py
@@ -33,3 +33,17 @@ class TokenCreate(BaseModel):
     refresh_token: str
     status: bool
     created_at: datetime.datetime
+    
+class UserResponse(BaseModel):
+    id: int
+    username: str
+    email: EmailStr
+    first_name: str
+    last_name: str
+    is_active: bool
+    profile_image: str | None = None
+    create_at: datetime.datetime
+    updated_at: datetime.datetime | None = None
+
+    class Config:
+        orm_mode = True

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from routers.role_routers import role_routers
 from routers.body_part_routers import body_part_router
 from routers.exercise_routers import exercise_router
 from routers.exercise_video_routers import exercise_video_router
+from routers.user_routers import user_setting_router
 
 origins = ["http://localhost:5173"]
 
@@ -58,6 +59,11 @@ def start_application():
     static_files_path = "/videos"
     os.makedirs(static_files_path, exist_ok=True)
     app.mount("/videos", StaticFiles(directory=static_files_path), name="videos")
+    app.mount(
+        "/profile_images",
+        StaticFiles(directory="/profile_images"),
+        name="profile_images",
+    )
     create_table()
     return app
 
@@ -70,6 +76,7 @@ app.include_router(role_routers)
 app.include_router(body_part_router)
 app.include_router(exercise_router)
 app.include_router(exercise_video_router)
+app.include_router(user_setting_router)
 
 
 @app.get("/")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -18,6 +18,7 @@ class User(Base):
     last_name = Column(String)
     is_active = Column(Boolean, default=1)  # 1 for active, 0 for inactive
     create_at = Column(DateTime, default=datetime.datetime.now)
+    prfile_image = Column(String, nullable=True)
     updated_at = Column(
         DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now
     )

--- a/backend/routers/user_routers.py
+++ b/backend/routers/user_routers.py
@@ -1,0 +1,66 @@
+# Stwórz nowy plik, np. routers/user.py
+
+from fastapi import APIRouter, Depends, HTTPException, status, File, UploadFile
+from sqlalchemy.orm import Session
+import os
+import shutil
+from datetime import datetime
+
+from db.session import get_db
+from auth.utils import get_current_user
+from models.user import User
+from auth.schemas import UserResponse 
+
+user_setting_router = APIRouter(
+    prefix="/users",
+    tags=["Users"]
+)
+
+@user_setting_router.post(
+    "/upload-profile-image",
+    response_model=UserResponse,
+    summary="Upload or change user's profile picture"
+)
+async def upload_profile_image(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Pozwala zalogowanemu użytkownikowi na wgranie lub zmianę zdjęcia profilowego.
+    Stare zdjęcie jest usuwane, jeśli istnieje.
+    """
+    storage_path = "/profile_images"
+    os.makedirs(storage_path, exist_ok=True) 
+
+    if current_user.profile_image and os.path.exists(current_user.profile_image):
+        try:
+            os.remove(current_user.profile_image)
+        except OSError as e:
+            print(f"Error deleting old profile picture: {e}")
+
+    file_extension = os.path.splitext(file.filename)[1].lower()
+    if file_extension not in [".jpg", ".jpeg", ".png"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid file type. Only .jpg, .jpeg, .png are allowed."
+        )
+    
+    new_filename = f"user_{current_user.id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}{file_extension}"
+    
+    full_save_path = os.path.join(storage_path, new_filename)
+    
+    try:
+        with open(full_save_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Could not save file: {e}"
+        )
+
+    current_user.profile_image = full_save_path
+    db.commit()
+    db.refresh(current_user)
+
+    return current_user


### PR DESCRIPTION
Closes #27

 ## What was done?

- Added a new endpoint POST /users/upload-profile-image for uploading and changing profile pictures.
- The endpoint is secured and only accessible to the logged-in user it concerns.
- Implemented file saving logic in a dedicated, mapped directory /profile_images.
- After uploading a new image, the file path is updated in the profile_image column in the users table.
- The old profile picture is automatically deleted from the server if it existed.
- Added validation that only accepts .jpg, .jpeg, and .png file types.

## Configuration changes
For this functionality to work, the reviewer must make the following changes to their local configuration:

I**In `main.py`:**  Mount the new static directory and register the router:
```python
from routers import user_router

app.mount("/profile_images", StaticFiles(directory="/profile_images"), name="profile_images")
app.include_router(user_setting_router)
```python


## How to test?

1. Run the application after making the configuration changes.
2. Go to the API documentation at /docs.
3. Find and expand the POST /users/upload-profile-image endpoint.
4. Authenticate using the "Authorize" button.
5. Use the "Try it out" button and select an image file to upload.
6. Check if the response has status 200 OK and contains updated user data.
7. Check if the file appears in the profile_images folder in your project.