### PR TITLE
feat(auth): Implement user password change functionality

### DIFF
--- a/backend/auth/schemas.py
+++ b/backend/auth/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 import datetime
 
 
@@ -48,3 +48,10 @@ class UserResponse(BaseModel):
 
     class Config:
         orm_mode = True
+
+class ChangePasswordRequest(BaseModel):
+    old_password: str
+    new_password: str = Field(min_length=8, description="Password must be at least 8 characters long")
+    confirm_password: str
+    
+    

--- a/frontend/src/pages/AccountSettingsPage.tsx
+++ b/frontend/src/pages/AccountSettingsPage.tsx
@@ -2,95 +2,163 @@ import React from 'react';
 import { useState, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useAuth } from '../context/AuthContext';
-import { uploadProfileImage } from '../services/api';
+import { uploadProfileImage, changePassword } from '../services/api';
 import MainLayout from '../components/MainLayout';
 import { Camera } from 'lucide-react';
 
 const AccountSettingsPage = () => {
-  const { user, updateUserContext } = useAuth(); 
-  const [newImageFile, setNewImageFile] = useState<File | null>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+    const { user, updateUserContext } = useAuth();
+    const [newImageFile, setNewImageFile] = useState<File | null>(null);
+    const [preview, setPreview] = useState<string | null>(null);
+    const [isChangePasswordVisible, setIsChangePasswordVisible] = useState(false);
+    const [oldPassword, setOldPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [passwordMessage, setPasswordMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    if (acceptedFiles?.length) {
-      const file = acceptedFiles[0];
-      setNewImageFile(file);
-      const previewUrl = URL.createObjectURL(file);
-      setPreview(previewUrl);
-    }
-  }, []);
+    const onDrop = useCallback((acceptedFiles: File[]) => {
+        if (acceptedFiles?.length) {
+            const file = acceptedFiles[0];
+            setNewImageFile(file);
+            const previewUrl = URL.createObjectURL(file);
+            setPreview(previewUrl);
+        }
+    }, []);
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    accept: { 'image/jpeg': [], 'image/png': [] },
-    maxFiles: 1,
-    multiple: false,
-  });
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({
+        onDrop,
+        accept: { 'image/jpeg': [], 'image/png': [] },
+        maxFiles: 1,
+        multiple: false,
+    });
 
-  const handleUpload = async () => {
-    if (!newImageFile) return;
+    const handleUpload = async () => {
+        if (!newImageFile) return;
 
-    setIsLoading(true);
-    setError(null);
+        setIsLoading(true);
+        setError(null);
 
-    try {
-      const updatedUser = await uploadProfileImage(newImageFile);
-      updateUserContext(updatedUser); 
-      alert('Zdjęcie profilowe zostało zaktualizowane!');
-      setNewImageFile(null);
-      setPreview(null);
-      window.location.reload();
-    } catch (err: any) {
-      setError(err.message || 'Wystąpił nieoczekiwany błąd.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-  
-  const currentImageUrl = user?.profile_image 
-    ? `http://localhost:8080${user.profile_image}` 
-    : '/images/avatar.png';
+        try {
+            const updatedUser = await uploadProfileImage(newImageFile);
+            updateUserContext(updatedUser);
+            alert('Zdjęcie profilowe zostało zaktualizowane!');
+            setNewImageFile(null);
+            setPreview(null);
+            window.location.reload();
+        } catch (err: any) {
+            setError(err.message || 'Wystąpił nieoczekiwany błąd.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+    const handleChangePassword = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setPasswordMessage(null);
 
-  return (
-    <MainLayout>
-      <h1 className="text-3xl font-bold mb-6 text-white">Ustawienia Konta</h1>
-      <div className="bg-gray-800 p-8 rounded-lg max-w-md mx-auto">
-        <div className="flex flex-col items-center">
-          <div {...getRootProps()} className="relative cursor-pointer group">
-            <img
-              src={preview || currentImageUrl}
-              alt="Zdjęcie profilowe"
-              className="w-40 h-40 rounded-full object-cover border-4 border-gray-600 group-hover:opacity-50 transition-opacity"
-            />
-            <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity">
-              <Camera className="text-white" size={48} />
+        if (newPassword !== confirmPassword) {
+            setPasswordMessage({ type: 'error', text: 'Nowe hasła nie są identyczne.' });
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await changePassword({ old_password: oldPassword, new_password: newPassword, confirm_password: confirmPassword });
+            setPasswordMessage({ type: 'success', text: 'Hasło zostało pomyślnie zmienione!' });
+            setOldPassword('');
+            setNewPassword('');
+            setConfirmPassword('');
+            setIsChangePasswordVisible(false);
+        } catch (err: any) {
+            setPasswordMessage({ type: 'error', text: err.message || 'Wystąpił błąd.' });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const currentImageUrl = user?.profile_image
+        ? `http://localhost:8080${user.profile_image}`
+        : '/images/avatar.png';
+
+    return (
+        <MainLayout>
+            <h1 className="text-3xl font-bold mb-6 text-white">Ustawienia Konta</h1>
+            <div className="bg-gray-800 p-8 rounded-lg max-w-md mx-auto">
+                <div className="flex flex-col items-center">
+                    <div {...getRootProps()} className="relative cursor-pointer group">
+                        <img
+                            src={preview || currentImageUrl}
+                            alt="Zdjęcie profilowe"
+                            className="w-40 h-40 rounded-full object-cover border-4 border-gray-600 group-hover:opacity-50 transition-opacity"
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity">
+                            <Camera className="text-white" size={48} />
+                        </div>
+                        <input {...getInputProps()} />
+                    </div>
+
+                    {isDragActive && <p className="mt-4 text-indigo-400">Upuść zdjęcie tutaj...</p>}
+
+                    <div className="mt-6 w-full">
+                        {newImageFile && (
+                            <div className="flex flex-col items-center">
+                                <p className="text-gray-300 mb-4">Wybrano: {newImageFile.name}</p>
+                                <button
+                                    onClick={handleUpload}
+                                    disabled={isLoading}
+                                    className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:bg-gray-500"
+                                >
+                                    {isLoading ? 'Zapisywanie...' : 'Zapisz nowe zdjęcie'}
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                    {error && <p className="mt-4 text-red-500">{error}</p>}
+                </div>
+                <hr className="border-gray-600" />
+
+                <div className="flex flex-col items-center">
+                    <h2 className="text-xl font-semibold text-white mb-4">Zmień hasło</h2>
+                    {!isChangePasswordVisible && (
+                        <button onClick={() => setIsChangePasswordVisible(true)} className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-500">
+                            Zmień hasło
+                        </button>
+                    )}
+
+                    {isChangePasswordVisible && (
+                        <form onSubmit={handleChangePassword} className="w-full space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-300 mb-1">Stare hasło</label>
+                                <input type="password" value={oldPassword} onChange={(e) => setOldPassword(e.target.value)} required className="w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white" />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-300 mb-1">Nowe hasło</label>
+                                <input type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required minLength={8} className="w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white" />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-300 mb-1">Potwierdź nowe hasło</label>
+                                <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className="w-full bg-gray-700 border border-gray-600 rounded-md py-2 px-3 text-white" />
+                            </div>
+                            <div className="flex gap-4">
+                                <button type="submit" disabled={isLoading} className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:bg-gray-500">
+                                    {isLoading ? 'Zmienianie...' : 'Potwierdź zmianę'}
+                                </button>
+                                <button type="button" onClick={() => setIsChangePasswordVisible(false)} className="flex-1 px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-500">
+                                    Anuluj
+                                </button>
+                            </div>
+                        </form>
+                    )}
+                    {passwordMessage && (
+                        <p className={`mt-4 text-sm ${passwordMessage.type === 'success' ? 'text-green-400' : 'text-red-500'}`}>
+                            {passwordMessage.text}
+                        </p>
+                    )}
+                </div>
             </div>
-            <input {...getInputProps()} />
-          </div>
-          
-          {isDragActive && <p className="mt-4 text-indigo-400">Upuść zdjęcie tutaj...</p>}
-
-          <div className="mt-6 w-full">
-            {newImageFile && (
-              <div className="flex flex-col items-center">
-                <p className="text-gray-300 mb-4">Wybrano: {newImageFile.name}</p>
-                <button
-                  onClick={handleUpload}
-                  disabled={isLoading}
-                  className="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:bg-gray-500"
-                >
-                  {isLoading ? 'Zapisywanie...' : 'Zapisz nowe zdjęcie'}
-                </button>
-              </div>
-            )}
-          </div>
-          {error && <p className="mt-4 text-red-500">{error}</p>}
-        </div>
-      </div>
-    </MainLayout>
-  );
+        </MainLayout>
+    );
 };
 
 export default AccountSettingsPage;

--- a/frontend/src/pages/FindExercisePage.tsx
+++ b/frontend/src/pages/FindExercisePage.tsx
@@ -1,108 +1,108 @@
 import React, { useState, useEffect } from 'react';
 import MainLayout from '../components/MainLayout';
-import { getBodyParts, getExercisesByBodyPart, ExerciseWithTrainer } from '../services/api'; 
+import { getBodyParts, getExercisesByBodyPart, ExerciseWithTrainer } from '../services/api';
 
 interface BodyPart {
-  id: number;
-  body_part_name: string;
+    id: number;
+    body_part_name: string;
 }
 
 const FindExercisePage = () => {
-  const [bodyParts, setBodyParts] = useState<BodyPart[]>([]);
-  const [selectedBodyPart, setSelectedBodyPart] = useState<BodyPart | null>(null);
-  const [exercises, setExercises] = useState<ExerciseWithTrainer[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+    const [bodyParts, setBodyParts] = useState<BodyPart[]>([]);
+    const [selectedBodyPart, setSelectedBodyPart] = useState<BodyPart | null>(null);
+    const [exercises, setExercises] = useState<ExerciseWithTrainer[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchInitialData = async () => {
-      try {
-        const parts = await getBodyParts();
-        setBodyParts(parts);
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setIsLoading(false);
-      }
+    useEffect(() => {
+        const fetchInitialData = async () => {
+            try {
+                const parts = await getBodyParts();
+                setBodyParts(parts);
+            } catch (err: any) {
+                setError(err.message);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchInitialData();
+    }, []);
+
+    const handleSelectBodyPart = async (part: BodyPart) => {
+        setSelectedBodyPart(part);
+        setIsLoading(true);
+        setError(null);
+        try {
+            const exercisesData = await getExercisesByBodyPart(part.id);
+            setExercises(exercisesData);
+        } catch (err: any) {
+            setError(err.message);
+            setExercises([]);
+        } finally {
+            setIsLoading(false);
+        }
     };
-    fetchInitialData();
-  }, []);
 
-  const handleSelectBodyPart = async (part: BodyPart) => {
-    setSelectedBodyPart(part);
-    setIsLoading(true);
-    setError(null);
-    try {
-      const exercisesData = await getExercisesByBodyPart(part.id);
-      setExercises(exercisesData);
-    } catch (err: any) {
-      setError(err.message);
-      setExercises([]);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const renderExercisesTable = () => (
-    <div>
-      <button 
-        onClick={() => setSelectedBodyPart(null)} 
-        className="mb-6 px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-500 transition-colors"
-      >
-        &larr; Wróć do wyboru partii
-      </button>
-      <h2 className="text-2xl font-semibold text-white mb-4">
-        Ćwiczenia dla: <span className="text-indigo-400">{selectedBodyPart?.body_part_name}</span>
-      </h2>
-      {isLoading ? (
-        <p className="text-white">Ładowanie ćwiczeń...</p>
-      ) : exercises.length > 0 ? (
-        <div className="overflow-x-auto bg-gray-800 rounded-lg">
-          <table className="min-w-full text-sm text-left text-gray-300">
-            <thead className="text-xs text-gray-400 uppercase bg-gray-700">
-              <tr>
-                <th scope="col" className="px-6 py-3">Nazwa ćwiczenia</th>
-                <th scope="col" className="px-6 py-3">Dodane przez</th>
-              </tr>
-            </thead>
-            <tbody>
-              {exercises.map(exercise => (
-                <tr key={exercise.id} className="border-b border-gray-700 hover:bg-gray-600">
-                  <td className="px-6 py-4 font-medium text-white">{exercise.exercise_name}</td>
-                  <td className="px-6 py-4">{`${exercise.user.first_name} ${exercise.user.last_name}`}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    const renderExercisesTable = () => (
+        <div>
+            <button
+                onClick={() => setSelectedBodyPart(null)}
+                className="mb-6 px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-500 transition-colors"
+            >
+                &larr; Wróć do wyboru partii
+            </button>
+            <h2 className="text-2xl font-semibold text-white mb-4">
+                Ćwiczenia dla: <span className="text-indigo-400">{selectedBodyPart?.body_part_name}</span>
+            </h2>
+            {isLoading ? (
+                <p className="text-white">Ładowanie ćwiczeń...</p>
+            ) : exercises.length > 0 ? (
+                <div className="overflow-x-auto bg-gray-800 rounded-lg">
+                    <table className="min-w-full text-sm text-left text-gray-300">
+                        <thead className="text-xs text-gray-400 uppercase bg-gray-700">
+                            <tr>
+                                <th scope="col" className="px-6 py-3">Nazwa ćwiczenia</th>
+                                <th scope="col" className="px-6 py-3">Dodane przez</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {exercises.map(exercise => (
+                                <tr key={exercise.id} className="border-b border-gray-700 hover:bg-gray-600">
+                                    <td className="px-6 py-4 font-medium text-white">{exercise.exercise_name}</td>
+                                    <td className="px-6 py-4">{`${exercise.user.first_name} ${exercise.user.last_name}`}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            ) : (
+                <p className="text-white">Brak dostępnych ćwiczeń dla tej partii ciała.</p>
+            )}
         </div>
-      ) : (
-        <p className="text-white">Brak dostępnych ćwiczeń dla tej partii ciała.</p>
-      )}
-    </div>
-  );
+    );
 
-  const renderBodyPartSelection = () => (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-       {bodyParts.map((part) => (
-         <button
-           key={part.id}
-           onClick={() => handleSelectBodyPart(part)}
-           className="p-6 bg-gray-700 rounded-lg text-white font-semibold text-center hover:bg-indigo-600 transition-colors"
-         >
-           {part.body_part_name}
-         </button>
-       ))}
-     </div>
- );
-  return (
-    <MainLayout>
-      <h1 className="text-3xl font-bold mb-6 text-white">Znajdź Ćwiczenie</h1>
-      {isLoading && !selectedBodyPart && <p className="text-white">Ładowanie partii ciała...</p>}
-      {error && <p className="text-red-500">Błąd: {error}</p>}
-      
-      {!isLoading && (selectedBodyPart ? renderExercisesTable() : renderBodyPartSelection())}
-    </MainLayout>
-  );
+    const renderBodyPartSelection = () => (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {bodyParts.map((part) => (
+                <button
+                    key={part.id}
+                    onClick={() => handleSelectBodyPart(part)}
+                    className="p-6 bg-gray-700 rounded-lg text-white font-semibold text-center hover:bg-indigo-600 transition-colors"
+                >
+                    {part.body_part_name}
+                </button>
+            ))}
+        </div>
+    );
+    return (
+        <MainLayout>
+            <h1 className="text-3xl font-bold mb-6 text-white">Znajdź Ćwiczenie</h1>
+            {isLoading && !selectedBodyPart && <p className="text-white">Ładowanie partii ciała...</p>}
+            {error && <p className="text-red-500">Błąd: {error}</p>}
+
+            {!isLoading && (selectedBodyPart ? renderExercisesTable() : renderBodyPartSelection())}
+        </MainLayout>
+    );
 };
 
 export default FindExercisePage;

--- a/frontend/src/services/api.tsx
+++ b/frontend/src/services/api.tsx
@@ -177,3 +177,23 @@ export const uploadProfileImage = async (file: File): Promise<User> => {
     throw new Error("Nie można było wysłać pliku. Sprawdź połączenie.");
   }
 };
+
+
+
+interface ChangePasswordData {
+  old_password: string;
+  new_password: string;
+  confirm_password: string;
+}
+
+
+export const changePassword = async (data: ChangePasswordData): Promise<void> => {
+  try {
+    await apiClient.post('/auth/change-password', data);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.detail || "Błąd podczas zmiany hasła");
+    }
+    throw new Error("Nie można było zmienić hasła. Sprawdź połączenie.");
+  }
+};


### PR DESCRIPTION
Closes #30

## What was done?
This change introduces complete functionality for changing passwords by logged-in users on the "Account Settings" page.

## Backend Changes:

- Created a new, secure endpoint POST /auth/change-password that operates on the logged-in user (retrieved from token).
- Added validation checking the correctness of the old password and matching of the new password with its confirmation.
- Implemented a new Pydantic schema ChangePasswordRequest to handle input data.


## Frontend Changes:

- Extended the Account Settings page by adding a password change section.
- The form is initially hidden and appears after clicking the "Change Password" button.
- Implemented client-side validation logic and handling of success or error messages.
- Added changePassword function to the API service to communicate with the new endpoint.


## How to test?

1. Log in to a user account.
2. Go to the "Account Settings" page.
3. Click the "Change Password" button.
4. Try entering an incorrect old password - you should see an error message.
5. Try entering a new password and different confirmation - you should see an error message.
6. Enter correct data and click "Confirm Change".
7. Check if a success message appears and the form disappears.

## ScreenShot

<img width="436" height="576" alt="image" src="https://github.com/user-attachments/assets/6cb6dbe2-d9b6-4eab-8a86-bb5942af3f97" />
