### PR TITLE
feat(exercises): Implement exercise detail view with video playback

### DIFF
--- a/backend/schemas/exercise.py
+++ b/backend/schemas/exercise.py
@@ -43,7 +43,17 @@ class ExerciseTrainerResponse(BaseModel):
 class ExerciseWithTrainerResponse(BaseModel):
     id: int
     exercise_name: str
-    user: ExerciseTrainerResponse  
+    user: ExerciseTrainerResponse
+
+    class Config:
+        orm_mode = True
+
+
+class ExerciseDetailResponse(BaseModel):
+    id: int
+    exercise_name: str
+    description: str | None
+    video_path: str | None
 
     class Config:
         orm_mode = True

--- a/frontend/src/services/api.tsx
+++ b/frontend/src/services/api.tsx
@@ -1,13 +1,13 @@
 
 import axios from 'axios';
-import {User} from '../context/AuthContext';
+import { User } from '../context/AuthContext';
 interface BodyPart {
   id: number;
   body_part_name: string;
 }
 
 const apiClient = axios.create({
-  baseURL: 'http://localhost:8080', 
+  baseURL: 'http://localhost:8080',
   headers: {
     'Content-Type': 'application/json',
   },
@@ -16,11 +16,11 @@ const apiClient = axios.create({
 apiClient.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('token');
-    
+
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;
     }
-    
+
     return config;
   },
   (error) => {
@@ -124,12 +124,12 @@ export const getMyExercises = async (): Promise<UserExercise[]> => {
 
 export const deleteExercise = async (exerciseId: number): Promise<void> => {
   try {
-      await apiClient.delete(`/exercise/${exerciseId}`);
+    await apiClient.delete(`/exercise/${exerciseId}`);
   } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-          throw new Error(error.response.data.detail || "Błąd podczas usuwania ćwiczenia");
-      }
-      throw new Error("Nie można usunąć ćwiczenia. Sprawdź połączenie.");
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.detail || "Błąd podczas usuwania ćwiczenia");
+    }
+    throw new Error("Nie można usunąć ćwiczenia. Sprawdź połączenie.");
   }
 };
 
@@ -142,7 +142,7 @@ interface ExerciseTrainer {
 export interface ExerciseWithTrainer {
   id: number;
   exercise_name: string;
-  user: ExerciseTrainer; 
+  user: ExerciseTrainer;
 }
 
 
@@ -195,5 +195,24 @@ export const changePassword = async (data: ChangePasswordData): Promise<void> =>
       throw new Error(error.response.data.detail || "Błąd podczas zmiany hasła");
     }
     throw new Error("Nie można było zmienić hasła. Sprawdź połączenie.");
+  }
+};
+
+export interface ExerciseDetails {
+  id: number;
+  exercise_name: string;
+  description: string | null;
+  video_path: string | null;
+}
+
+export const getExerciseDetails = async (exerciseId: number): Promise<ExerciseDetails> => {
+  try {
+    const response = await apiClient.get<ExerciseDetails>(`/exercise/${exerciseId}/details`);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.detail || "Błąd podczas pobierania szczegółów ćwiczenia");
+    }
+    throw new Error("Nie można pobrać danych ćwiczenia.");
   }
 };


### PR DESCRIPTION
Closes #31
## What was done?
This change introduces key functionality for users, allowing them to view details of a selected exercise, including playback of instructional video from the trainer.

## Backend Changes:
- Created a new endpoint `GET /exercise/{exercise_id}/details`, that returns the name, description, and video path for a specific exercise.
- Added a new Pydantic schema `ExerciseDetailResponse` for output data validation.

## Frontend Changes:
- **Detail view:** Implemented a new `ExerciseDetailModal` component that appears after clicking on an exercise from the list.
- **Video playback:** The modal contains a video player that automatically starts the instructional recording.
- **Interactivity:** Added a "Compare technique" button that at this stage logs the video path to the console, and a "Back" button to close the window.
- **API service:** Extended `services/api.ts` with a new getExerciseDetails function to communicate with the backend.

## How to test?

1. Log in to a **user account.**
2. Go to the **"Find Exercise" page.**
3. Select a body part that has exercises with uploaded video.
4. Click on any row in the exercise table.
5. **Check if:**

- A modal window appeared with the correct exercise name and description.
- The instructional video plays correctly.
- The "Compare technique" button is active (if there's a video) and displays an alert and console log when clicked.
- The "Back" button (or clicking the background) closes the window.

## Screenshot
<img width="767" height="654" alt="image" src="https://github.com/user-attachments/assets/40a7f44c-afc9-4cac-a62f-cac1a8bbb0ff" />